### PR TITLE
feat: add async call example

### DIFF
--- a/async_call/client/main.go
+++ b/async_call/client/main.go
@@ -1,0 +1,93 @@
+// Copyright 2021 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"github.com/cloudwego/kitex-examples/kitex_gen/api"
+	"github.com/cloudwego/kitex-examples/kitex_gen/api/echo"
+	"github.com/cloudwego/kitex/client"
+	"log"
+	"strings"
+	"time"
+)
+
+func NewFuture(f func() (interface{}, error)) func() (interface{}, error) {
+	var res interface{}
+	var err error
+
+	c := make(chan struct{}, 1)
+	go func() {
+		defer close(c)
+		res, err = f()
+	}()
+	return func() (interface{}, error) {
+		<-c
+		return res, err
+	}
+}
+
+func sequentialCall(client echo.Client) {
+
+	for i := 1; i < 5; i++ {
+		var req = &api.Request{Message: "my request"}
+		resp, err := client.Echo(context.Background(), req)
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Println(resp)
+	}
+}
+
+func asyncParallelCall(client echo.Client) {
+	var futures []func() (interface{}, error)
+	for i := 0; i < 5; i++ {
+		var req = &api.Request{Message: "my request"}
+
+		futures = append(futures, NewFuture(func() (interface{}, error) {
+			return client.Echo(context.Background(), req)
+		}))
+
+	}
+	for i := 0; i < 5; i++ {
+		resp, err := futures[i]()
+		if err != nil {
+			log.Fatal(err)
+		}
+		log.Println(resp)
+	}
+}
+
+func main() {
+	client, err := echo.NewClient("echo", client.WithHostPorts("[::1]:8888"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Println(strings.Repeat("=", 10))
+	fmt.Println("sequential call")
+	t0 := time.Now()
+	sequentialCall(client)
+	fmt.Println("cast time: " + time.Now().Sub(t0).String())
+
+	fmt.Println(strings.Repeat("=", 10))
+	fmt.Println("async parallel call")
+	t1 := time.Now()
+	asyncParallelCall(client)
+	fmt.Println("cast time: " + time.Now().Sub(t1).String())
+
+}

--- a/async_call/client/main.go
+++ b/async_call/client/main.go
@@ -82,12 +82,12 @@ func main() {
 	fmt.Println("sequential call")
 	t0 := time.Now()
 	sequentialCall(client)
-	fmt.Println("cast time: " + time.Now().Sub(t0).String())
+	fmt.Println("cast time: " + time.Since(t0).String())
 
 	fmt.Println(strings.Repeat("=", 10))
 	fmt.Println("async parallel call")
 	t1 := time.Now()
 	asyncParallelCall(client)
-	fmt.Println("cast time: " + time.Now().Sub(t1).String())
+	fmt.Println("cast time: " + time.Since(t1).String())
 
 }

--- a/async_call/client/main.go
+++ b/async_call/client/main.go
@@ -17,7 +17,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"github.com/cloudwego/kitex-examples/kitex_gen/api"
 	"github.com/cloudwego/kitex-examples/kitex_gen/api/echo"
 	"github.com/cloudwego/kitex/client"
@@ -78,16 +77,16 @@ func main() {
 		log.Fatal(err)
 	}
 
-	fmt.Println(strings.Repeat("=", 10))
-	fmt.Println("sequential call")
+	log.Println(strings.Repeat("=", 10))
+	log.Println("sequential call")
 	t0 := time.Now()
 	sequentialCall(client)
-	fmt.Println("cast time: " + time.Since(t0).String())
+	log.Println("cast time: " + time.Since(t0).String())
 
-	fmt.Println(strings.Repeat("=", 10))
-	fmt.Println("async parallel call")
+	log.Println(strings.Repeat("=", 10))
+	log.Println("async parallel call")
 	t1 := time.Now()
 	asyncParallelCall(client)
-	fmt.Println("cast time: " + time.Since(t1).String())
+	log.Println("cast time: " + time.Since(t1).String())
 
 }

--- a/async_call/server/main.go
+++ b/async_call/server/main.go
@@ -1,0 +1,47 @@
+// Copyright 2021 CloudWeGo Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+package main
+
+import (
+	"context"
+	"github.com/cloudwego/kitex-examples/kitex_gen/api"
+	"github.com/cloudwego/kitex-examples/kitex_gen/api/echo"
+	"github.com/cloudwego/kitex/pkg/klog"
+	"log"
+	"time"
+)
+
+var _ api.Echo = &EchoImpl{}
+
+// EchoImpl implements the last service interface defined in the IDL.
+type EchoImpl struct{}
+
+// Echo implements the Echo interface.
+func (s *EchoImpl) Echo(ctx context.Context, req *api.Request) (resp *api.Response, err error) {
+	klog.Info("echo called")
+	//computing...
+	time.Sleep(time.Duration(1) * time.Second)
+	return &api.Response{Message: req.Message}, nil
+}
+
+func main() {
+	svr := echo.NewServer(new(EchoImpl))
+	if err := svr.Run(); err != nil {
+		log.Println("server stopped with error:", err)
+	} else {
+		log.Println("server stopped")
+	}
+}


### PR DESCRIPTION
run log:

```shell
2022/06/21 20:24:59 ==========
2022/06/21 20:24:59 sequential call
2022/06/21 20:25:00 Response({Message:my request})
2022/06/21 20:25:01 Response({Message:my request})
2022/06/21 20:25:02 Response({Message:my request})
2022/06/21 20:25:03 Response({Message:my request})
2022/06/21 20:25:03 cast time: 4.009205292s
2022/06/21 20:25:03 ==========
2022/06/21 20:25:03 async parallel call
2022/06/21 20:25:04 Response({Message:my request})
2022/06/21 20:25:04 Response({Message:my request})
2022/06/21 20:25:04 Response({Message:my request})
2022/06/21 20:25:04 Response({Message:my request})
2022/06/21 20:25:04 Response({Message:my request})
2022/06/21 20:25:04 cast time: 1.001620055s
```
