### PR TITLE
fix: pid error in hello example by upgrading github.com/choleraehyq/pid

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/HdrHistogram/hdrhistogram-go v1.1.2 // indirect
 	github.com/apache/thrift v0.13.0
 	github.com/bytedance/gopkg v0.0.0-20220531084716-665b4f21126f
+	github.com/choleraehyq/pid v0.0.15 // indirect
 	github.com/cloudwego/kitex v0.3.3-0.20220624100129-57c0ee22edd9
 	github.com/kitex-contrib/monitor-prometheus v0.0.0-20210817080809-024dd7bd51e1
 	github.com/kitex-contrib/obs-opentelemetry v0.0.0-20220601144657-c60210e3c928

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/choleraehyq/pid v0.0.12/go.mod h1:uhzeFgxJZWQsZulelVQZwdASxQ9TIPZYL4TPkQMtL/U=
 github.com/choleraehyq/pid v0.0.13 h1:Tc/jYjHC50SDCxSX+DWHfMmFqtwGR8EiQ08qJ/EK8zs=
 github.com/choleraehyq/pid v0.0.13/go.mod h1:uhzeFgxJZWQsZulelVQZwdASxQ9TIPZYL4TPkQMtL/U=
+github.com/choleraehyq/pid v0.0.15 h1:PejhUZowqxxssjwyaw4OZURRFjnvftZfeEWK9UoWPXU=
+github.com/choleraehyq/pid v0.0.15/go.mod h1:uhzeFgxJZWQsZulelVQZwdASxQ9TIPZYL4TPkQMtL/U=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=


### PR DESCRIPTION
fix: pid error in hello example by upgrading github.com/choleraehyq/pid v0.0.13 => v0.0.15

#### What type of PR is this?
fix: A bug fix

the error:
```
go: downloading golang.org/x/text v0.3.6
# github.com/choleraehyq/pid
/users/amio/go/pkg/mod/github.com/choleraehyq/pid@v0.0.13/pid_go1.5_amd64.s:28: expected pseudo-register; found R13
/users/amio/go/pkg/mod/github.com/choleraehyq/pid@v0.0.13/pid_go1.5_amd64.s:29: expected pseudo-register; found R14
asm: assembly of /users/amio/go/pkg/mod/github.com/choleraehyq/pid@v0.0.13/pid_go1.5_amd64.s failed
```

#### What this PR does / why we need it (en: English/zh: Chinese):
<!--
The description will be attached in Release Notes, 
so please describe it from user-oriented.
-->
en: Fixed the pid error when running `hello` example
zh: 修复了运行 `hello` 示例时的 pid 报错
