### PR TITLE
build: modify Dockerfile to improve build speed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-FROM golang:1.16.6-alpine
+FROM golang:1.20.7-alpine3.17
 
 RUN apk update && apk add git
 
@@ -22,5 +22,6 @@ WORKDIR /code
 COPY . .
 RUN go env -w GOPROXY=https://goproxy.io,direct
 RUN go env -w GO111MODULE=on
+RUN go mod tidy
 RUN go build -o hello-client ./hello/client
 RUN go build -o hello-server  ./hello


### PR DESCRIPTION
add `go mod tidy` before `go build`, change the version of the dependent base image to golang:1.20.7-alpine3.17 (#1068)

#### What type of PR is this?
build: modified the image build file

#### Check the PR title.

- [x] This PR title match the format: \<type\>(optional scope): \<description\>
- [x] The description of this PR title is user-oriented and clear enough for others to understand.
- [x] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
在`go build`前添加`go mod tidy`，将依赖基础镜像的版本更改为golang:1.20.7-alpine3.17

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).

en:
The original version of the basic golang image would cause the build to fail, so its version was upgraded; adding `go mod tidy` before `go build` can make more effective use of the `Dockerfile` cache

zh(optional): 
原来的基础golang镜像版本会导致构建失败，所以升级了他的版本；在`go build`前添加`go mod tidy`能够更有效地利用`Dockerfile`缓存

#### (Optional) Which issue(s) this PR fixes:
<!--
Automatically closes linked issue when PR is merged.
Eg: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

#### (optional) The PR that updates user documentation:
<!--
If the current PR requires user awareness at the usage level, please submit a PR to update user docs. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)
-->
