### PR TITLE
fix: exception parameters and typo

### DIFF
--- a/basic/example_shop/rpc/item/main.go
+++ b/basic/example_shop/rpc/item/main.go
@@ -33,7 +33,7 @@ func main() {
 	}
 
 	itemServiceImpl := new(ItemServiceImpl)
-	stockCli, err := NewStockClient("0.0.0.0:8890")
+	stockCli, err := NewStockClient()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/basic/example_shop/rpc/stock/build.sh
+++ b/basic/example_shop/rpc/stock/build.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-RUN_NAME="example.shop.stok"
+RUN_NAME="example.shop.stock"
 
 mkdir -p output/bin
 cp script/* output/

--- a/basic/example_shop/rpc/stock/kitex_info.yaml
+++ b/basic/example_shop/rpc/stock/kitex_info.yaml
@@ -1,3 +1,3 @@
 kitexinfo:
-   ServiceName: 'example.shop.stok'
+   ServiceName: 'example.shop.stock'
    ToolVersion: 'v0.8.0'

--- a/basic/example_shop/rpc/stock/script/bootstrap.sh
+++ b/basic/example_shop/rpc/stock/script/bootstrap.sh
@@ -18,4 +18,4 @@ if [ ! -d "$KITEX_LOG_DIR/rpc" ]; then
     mkdir -p "$KITEX_LOG_DIR/rpc"
 fi
 
-exec "$CURDIR/bin/example.shop.stok"
+exec "$CURDIR/bin/example.shop.stock"


### PR DESCRIPTION

1. Delete useless parameters causing compilation failure. resolve https://github.com/cloudwego/kitex-examples/issues/123
2. Change the word stok to stock.